### PR TITLE
replace ':' delimiter with '@'

### DIFF
--- a/sqldb/sqldb.go
+++ b/sqldb/sqldb.go
@@ -100,7 +100,7 @@ func NewUser(name, email string) User {
 
 	userHash := sha256.Sum256([]byte(email))
 	userBits := base64.RawURLEncoding.EncodeToString(userHash[:])[:6]
-	code := "fullyhacks:" + randBits + userBits
+	code := "fullyhacks@" + randBits + userBits
 
 	return User{
 		Email: email,


### PR DESCRIPTION
Windows does not allow the following characters as part of filenames:

`\ / : * ? " < > |`

This PR updates the qrcode file delimiter from `:` to `@`, allowing these to be accessed on Windows, macOS, and Linux.